### PR TITLE
Use `summarise()` rather than `expand()`

### DIFF
--- a/R/ssimparser.R
+++ b/R/ssimparser.R
@@ -313,7 +313,8 @@ load_ssim <- function(ssim_file = get_ssim_sample(), nested_df = FALSE, collist 
   if (expand_sched)
   {
     ssimjoin %>%  dplyr::group_by_all() %>%
-      tidyr::expand(n_flight = seq(1:(diff_days + 1))) %>%
+      dplyr::summarise(n_flight = seq(1:(diff_days + 1))) %>%
+      dplyr::ungroup() %>%
       dplyr::filter(diff_days > 0 | (diff_days == 0 & n_flight == 1) ) %>%
       dplyr::mutate(flight.flight_date = type3.std_utc + (n_flight - 1)*24*60*60 ) %>%
       dplyr::rowwise() %>%


### PR DESCRIPTION
We are planning on releasing tidyr 1.2.0 towards the end of this month.

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run this example:

``` r
library(tidyverse)

# Get 3 samples as a character vector
samples <- data.frame(sampleid = c(1:3)) %>%
  dplyr::rowwise() %>%
  dplyr::mutate(filename = tempfile(),
                samplestring = ssimparser::get_ssim_sample(datefrom = as.Date("2020-11-01") + (sampleid * 3), dateto = as.Date("2020-12-01") + (sampleid * 3), season = "W20", creadate = as.Date("2020-11-01") + sampleid)
  )
# Write the samples to tempdir
for (i in 1:3)
{
  write(samples[i,]$samplestring, samples[i,]$filename, append = FALSE)
}
# Load the 3 samples and expand to flights
flights <- ssimparser::load_ssim_flights(ssim_files = samples$filename)
#> [1] "File to load has 17 rows"
#> [1] "data frame has 17 rows"
#> Error: Problem with `summarise()` input `..1`.
#> ℹ `..1 = expand(data = dplyr::cur_data(), ..., .name_repair = .name_repair)`.
#> x non-numeric argument to binary operator
#> ℹ The error occurred in group 1: type2.timemode = "L", type2.iata_airline = "AF", type2.blank1 = "     ", type2.season = "W20", type2.blank2 = " ", type2.valid_from = "04NOV20", type2.valid_to = "04DEC20", type2.creation_date = "02NOV20", type2.title_of_data = "SSIM EXAMPLE SCHEDULE        ", type2.release_date = "02NOV20", type2.schedule_status = "C", type2.creator_reference = "KENNY", type2.duplicate_airline_designator = "", type2.general_information = "TEST AIRLINE", type2.inflight_service_information = "1/8/13/18", type2.electronic_ticketing_information = "ET", type2.creation_time = "1800", type2.record_serial_number = 2, type2.next_record_serial_number = 9, n_type3 = 3, type3.operational_suffix = "X", type3.airline_designator = "AF", type3.flight_number = "1234", type3.itinerary_variation = "01", type3.leg_sequence = "01", type3.service_type = "J", type3.period_from = "04NOV20", type3.period_to = "19NOV20", type3.days_of_operation = "67", type3.frequency_rate = "2", type3.adep_iata = "CDG", type3.passenger_std = "1845", type3.std = "1945", type3.adep_utc_offset = "+0100", type3.adep_terminal = "T1", type3.ades_iata = "ALC", type3.sta = "2125", type3.passenger_sta = "2120", type3.ades_utc_offset = "+0100", type3.ades_terminal = "1F", type3.aircraft_type_iata = "320", type3.prbd = "XX", type3.meal_service = "XX        ", type3.joint_operation = "XX XX", type3.minimum_connecting_time_status = "XX", type3.secure_flight_indicator = "X", type3.blank1 = "     ", type3.itinerary_variation_overflow = "", type3.aircraft_owner = "XX", type3.cockpit_crew_employer = "XX ", type3.cabin_crew_employer = "XX ", type3.onward_flight_operator_iata = "XX ", type3.onward_flight_number = "1234", type3.aircraft_rotation_layover = " ", type3.onward_operation_suffix = " ", type3.blank2 = " ", type3.flight_transit_layower = "2", type3.code_sharing = "L", type3.traffic_restriction_code = " W         ", type3.traffic_restriction_code_leg = " ", type3.blank3 = "           ", type3.aircraft_configuration = "                    ", type3.date_variation = "00", type3.record_serial_number = 8, type3.next_record_serial_number = NA, type3.adep_icao = "LFPG", type3.ades_icao = "LEAL", type3.std_utc = 2020-11-04 18:45:00, type3.sta_utc = 2020-11-04 20:25:00, diff_days = 15, sta_utc = 2020-11-04 20:25:00, type3.period_from_utc = 2020-11-04, type3.period_to_utc = 2020-11-19.
```

The problem comes down to the fact that you were trying to call `expand()` with a grouped data frame, and you were trying to utilize the group columns. This is actually not well defined, as `expand()` completes "within" each group, so you really shouldn't have access to the group variables.  The previous behavior was problematic in many cases (see https://github.com/tidyverse/tidyr/issues/396 and https://github.com/tidyverse/tidyr/issues/966), so we've made a fix to ensure that `expand()` works correctly with grouped data frames in all cases. This fix comes with the restriction that now you can't specify the group variables in the call to `expand()`.

It looks like you were attempting to do something that can be accomplished with `summarise()`, so I've switched over to that instead.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!